### PR TITLE
Profile 도메인 수정

### DIFF
--- a/src/main/java/com/show/Profile.java
+++ b/src/main/java/com/show/Profile.java
@@ -1,45 +1,44 @@
 package com.show;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+import jakarta.annotation.Nonnull;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+import org.springframework.lang.NonNull;
 
+import java.util.HashSet;
+import java.util.Set;
+
+@Getter
 public class Profile {
-    final String profileId;
-    String picture;
-    String nickname;
-    String introduction;
-    List<Profile> followings;
-    List<Profile> followers;
-    List<String> uploadedVideos;
-    List<String> likedVideos;
-    String visibility;
+    public enum Visibility {
+        PUBLIC, PRIVATE
+    }
+    private final String id;
+    private String picture;
+    private String nickname;
+    private String intro;
+    private Set<Profile> followings;
+    private Set<Profile> followers;
+    private Visibility visibility;
+    private Set<Video> uploadedVideos;
+    private Set<Video> likedVideos;
 
-    public Profile(String profileId, String nickname) {
-        this.profileId = profileId;
-        this.nickname = nickname;
+    public Profile(String id) {
+        this.id = id;
 
-        this.followings = new ArrayList<>();
-        this.followers = new ArrayList<>();
-        this.visibility = "public";
+        this.visibility = Visibility.PUBLIC;
+        this.followings = new HashSet<>();
+        this.followers = new HashSet<>();
+        this.uploadedVideos = new HashSet<>();
+        this.likedVideos = new HashSet<>();
     }
 
-    public void changePicture(String newPicture) {
-        this.picture = newPicture;
-    }
-
-    public void changeNickname(String newNickname) {
-        this.nickname = newNickname;
-    }
-
-    public void changeIntroduction(String newIntroduction) {
-        this.introduction = newIntroduction;
-    }
-
-    private boolean isAlreadyFollowed(Profile user) {
+    public boolean isAlreadyFollowed(Profile user) {
         return followings.contains(user);
     }
 
+    // 팔로우, 언팔로우를 분리하는 게 좋을지.
     public void follow(Profile user) {
         if (isAlreadyFollowed(user)) {
             followings.remove(user);
@@ -50,31 +49,29 @@ public class Profile {
         user.followers.add(this);
     }
 
-    private boolean isPublic() {
-        return Objects.equals(this.visibility, "public");
+    public boolean isPublic() {
+        return this.visibility == Visibility.PUBLIC;
     }
 
     public void changeVisibility() {
         if (isPublic()) {
-            this.visibility = "private";
+            this.visibility = Visibility.PRIVATE;
             return ;
         }
-        this.visibility = "public";
+        this.visibility = Visibility.PUBLIC;
     }
 
-//    like 기능 보류
-//    private boolean isAlreadyLiked(String video) {
-//        return likes.contains(video);
-//    }
-//
-//    public void like(String video) {
-//        // 1. video가 likes 안에 있는지 찾는다.
-//        // 2. 1 조건에 만족하면 likes에서 video를 지운다.
-//        // 3. 1 조건에 만족하지 않으면 likes에 video를 추가한다.
-//        if(isAlreadyLiked(video)) {
-//            likes.remove(video);
-//            return;
-//        }
-//        likes.add(video);
-//    }
+    public boolean isAlreadyLiked(Video video) {
+        return likedVideos.contains(video);
+    }
+
+    public void like(Video video) {
+        if (isAlreadyLiked(video)) {
+            likedVideos.remove(video);
+            video.subtractLikes();
+            return ;
+        }
+        likedVideos.add(video);
+        video.addLikes();
+    }
 }

--- a/src/main/java/com/show/Profile.java
+++ b/src/main/java/com/show/Profile.java
@@ -2,34 +2,79 @@ package com.show;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 public class Profile {
+    final String profileId;
     String picture;
-    final String nickname;
-    final int profileId;
+    String nickname;
     String introduction;
-    List<String> videos;
     List<Profile> followings;
     List<Profile> followers;
-    List<String> likes = new ArrayList<>();
+    List<String> uploadedVideos;
+    List<String> likedVideos;
+    String visibility;
 
-    public Profile(String nickname, int profileId) {
-        this.nickname = nickname;
+    public Profile(String profileId, String nickname) {
         this.profileId = profileId;
+        this.nickname = nickname;
+
+        this.followings = new ArrayList<>();
+        this.followers = new ArrayList<>();
+        this.visibility = "public";
     }
 
-    private boolean isAlreadyLiked(String video) {
-        return likes.contains(video);
+    public void changePicture(String newPicture) {
+        this.picture = newPicture;
     }
 
-    public void like(String video) {
-        // 1. video가 likes 안에 있는지 찾는다.
-        // 2. 1 조건에 만족하면 likes에서 video를 지운다.
-        // 3. 1 조건에 만족하지 않으면 likes에 video를 추가한다.
-        if(isAlreadyLiked(video)) {
-            likes.remove(video);
-            return;
+    public void changeNickname(String newNickname) {
+        this.nickname = newNickname;
+    }
+
+    public void changeIntroduction(String newIntroduction) {
+        this.introduction = newIntroduction;
+    }
+
+    private boolean isAlreadyFollowed(Profile user) {
+        return followings.contains(user);
+    }
+
+    public void follow(Profile user) {
+        if (isAlreadyFollowed(user)) {
+            followings.remove(user);
+            user.followers.remove(this);
+            return ;
         }
-        likes.add(video);
+        followings.add(user);
+        user.followers.add(this);
     }
+
+    private boolean isPublic() {
+        return Objects.equals(this.visibility, "public");
+    }
+
+    public void changeVisibility() {
+        if (isPublic()) {
+            this.visibility = "private";
+            return ;
+        }
+        this.visibility = "public";
+    }
+
+//    like 기능 보류
+//    private boolean isAlreadyLiked(String video) {
+//        return likes.contains(video);
+//    }
+//
+//    public void like(String video) {
+//        // 1. video가 likes 안에 있는지 찾는다.
+//        // 2. 1 조건에 만족하면 likes에서 video를 지운다.
+//        // 3. 1 조건에 만족하지 않으면 likes에 video를 추가한다.
+//        if(isAlreadyLiked(video)) {
+//            likes.remove(video);
+//            return;
+//        }
+//        likes.add(video);
+//    }
 }

--- a/src/test/java/com/show/ProfileTest.java
+++ b/src/test/java/com/show/ProfileTest.java
@@ -2,34 +2,36 @@ package com.show;
 
 import org.junit.jupiter.api.Test;
 
+import static com.show.Profile.Visibility.PRIVATE;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ProfileTest {
 
     @Test
     void follow() {
-        Profile me = new Profile("@jjy1004", "judy");
-        Profile user = new Profile("@kmk2024", "pingu");
+        Profile me = new Profile("@jjy1004");
+        Profile user = new Profile("@kmk2024");
         me.follow(user);
 
-        assertEquals("pingu", me.followings.get(0).nickname);
-        assertEquals("judy", user.followers.get(0).nickname);
+        assertTrue(me.isAlreadyFollowed(user));
+        assertTrue(user.getFollowers().contains(me));
     }
 
     @Test
     void changeVisibility() {
-        Profile me = new Profile("@jjy1004", "judy");
+        Profile me = new Profile("@jjy1004");
         me.changeVisibility();
 
-        assertEquals("private", me.visibility);
+        assertFalse(me.isPublic());
+        assertEquals(PRIVATE, me.getVisibility());
     }
-//    @Test
-//    void like() {
-//        String video = "mp4";
-//        Profile profile = new Profile("jjy_0123", "juan");
-//        profile.like(video);
-//
-//
-//        assertEquals(video, profile.likes.get(0));
-//    }
+
+    @Test
+    void like() {
+        Profile me = new Profile("@jjy1004");
+        Video video = new Video("v001", "https://aws.com/video");
+
+        me.like(video);
+        assertTrue(me.isAlreadyLiked(video));
+    }
 }

--- a/src/test/java/com/show/ProfileTest.java
+++ b/src/test/java/com/show/ProfileTest.java
@@ -5,13 +5,31 @@ import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
 
 class ProfileTest {
+
     @Test
-    void like() {
-        String video = "mp4";
-        Profile profile = new Profile("juan", 1);
-        profile.like(video);
+    void follow() {
+        Profile me = new Profile("@jjy1004", "judy");
+        Profile user = new Profile("@kmk2024", "pingu");
+        me.follow(user);
 
-
-        assertEquals(video, profile.likes.get(0));
+        assertEquals("pingu", me.followings.get(0).nickname);
+        assertEquals("judy", user.followers.get(0).nickname);
     }
+
+    @Test
+    void changeVisibility() {
+        Profile me = new Profile("@jjy1004", "judy");
+        me.changeVisibility();
+
+        assertEquals("private", me.visibility);
+    }
+//    @Test
+//    void like() {
+//        String video = "mp4";
+//        Profile profile = new Profile("jjy_0123", "juan");
+//        profile.like(video);
+//
+//
+//        assertEquals(video, profile.likes.get(0));
+//    }
 }


### PR DESCRIPTION
## Motivation
- `Setter` 사용을 지양하여, 도메인 객체에 책임을 집중 시키고자 했습니다.

<br> 

## Key Changes
- `String` 대신 `Video` 도메인 타입으로 변경하였습니다.
- 프로필 공개 범위를 지정하는 `visibility`를 열거형 타입으로 변경하였습니다.
- 좋아요 기능을 추가하였습니다.
- `List` 타입 대신 `Set` 타입으로 변경하였습니다.

<br>

## To Reviewers
- 팔로우와 언팔로우 기능을 두 개의 로직으로 분리하는 게 좋을지 멘토님의 의견이 궁금합니다.